### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author = Rodrigues F. A. S. <rodriguesfas.github.io>
 maintainer = Rodrigues F. A. S. <franciscosouzaacer@gmail.com>
 sentence = Simples Lib. ler temperatura com sernsor LM35, nas escalas Celsius, Fahrenheit e Kelvin.
 paragraph = Esta biblioteca ajuda na implementação de leitura de temperatura com o sensor LM35 nas escalas Celsius, Fahrenheit e Kelvin.
-category = Sensores
+category = Sensors
 url = https://github.com/rodriguesfas/LM35
 architectures = *


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Sensores' in library LM35 is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format